### PR TITLE
save updates to flower and size prices

### DIFF
--- a/app/components/sizes/SizeSection.tsx
+++ b/app/components/sizes/SizeSection.tsx
@@ -14,8 +14,8 @@ export const SizeSection = ({
   const handleChange = useCallback(
     (selected: string[]) => {
       const newSelectedSizes = selected;
-      const sizeOptionValuesToAdd = newSelectedSizes.filter( x => !formState.prevSizesSelected.includes(x)); 
-      const sizeOptionValuesToRemove = formState.prevSizesSelected.filter( x => !newSelectedSizes.includes(x));
+      const sizeOptionValuesToAdd = newSelectedSizes.filter(x => !formState.prevSizesSelected.includes(x));
+      const sizeOptionValuesToRemove = formState.prevSizesSelected.filter(x => !newSelectedSizes.includes(x));
       setFormState({
         ...formState,
         sizesSelected: newSelectedSizes,
@@ -28,8 +28,8 @@ export const SizeSection = ({
 
   function inlineError(errors: FormErrors) {
     return (errors != null && errors.sizes != null)
-    ? (<InlineError message={errors.sizes} fieldID="size" />)
-    : null;
+      ? (<InlineError message={errors.sizes} fieldID="size" />)
+      : null;
   }
 
   return (

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,19 +1,46 @@
+import { PriceMetadata } from "./types";
+
 export const FOXTAIL_NAMESPACE = "foxtail";
 export const STORE_METADATA_CUSTOM_PRODUCT_KEY = "customProductId";
 export const PRODUCT_METADATA_PRICES = "prices";
+export const GRAPHQL_API_VERSION = "2024-07";
+
+// positions for Shopify product options
 export const FLOWER_POSITION = 1;
-export const FLOWER_OPTION_NAME = "Focal Flower";
 export const SIZE_POSITION = 2;
+export const PALETTE_POSITION = 3;
+
+// option names for Shopify product
+export const FLOWER_OPTION_NAME = "Focal Flower";
 export const SIZE_OPTION_NAME = "Size";
+export const PALETTE_OPTION_NAME = "Palette";
+
+// names for customization keys
+export const FLOWER_CUSTOMIZATION_SECTION_NAME = "flowers";
+export const PALETTE_CUSTOMIZATION_SECTION_NAME = "palettes";
+export const SIZE_CUSTOMIZATION_SECTION_NAME = "sizes";
+
+// default size values in different forms
 export const SIZE_OPTION_VALUES = ["Small", "Medium", "Large", "Extra-Large"];
-export const SIZE_TO_PRICE_DEFAULT_VALUES = {
+export const SIZE_TO_PRICE_DEFAULT_VALUES: {[key: string]: number} = {
     "Small": 40,
     "Medium": 50,
     "Large": 60,
     "Extra-Large": 70
 };
+
+
 export const SIZE_TO_PRICE_DEFAULT_VALUES_SERIALIZED = JSON.stringify(SIZE_TO_PRICE_DEFAULT_VALUES);
 
-export const PALETTE_POSITION = 3;
-export const PALETTE_OPTION_NAME = "Palette";
-export const GRAPHQL_API_VERSION = "2024-07";
+// default flower price values
+export const DEFAULT_FLOWER_PRICE = 0;
+
+export const FLOWER_TO_PRICE_DEFAULT_VALUES: {[key: string]: number} = {};
+
+// default price metadata values
+export const OPTION_TO_PRICE_DEFAULT_VALUES: PriceMetadata = {
+    sizeToPrice: SIZE_TO_PRICE_DEFAULT_VALUES,
+    flowerToPrice: FLOWER_TO_PRICE_DEFAULT_VALUES
+};
+
+export const OPTION_TO_PRICE_DEFAULT_VALUES_SERIALIZED = JSON.stringify(OPTION_TO_PRICE_DEFAULT_VALUES);

--- a/app/routes/app.bouquets.customize.tsx
+++ b/app/routes/app.bouquets.customize.tsx
@@ -29,6 +29,8 @@ import { getBYOBOptions } from "~/server/getBYOBOptions";
 import { CustomizationSection } from "~/components/customizations/CustomizationSection";
 import { Flower, Palette } from "@prisma/client";
 import { Palette as PaletteComponent } from "~/components/palettes/Palette";
+import { FLOWER_OPTION_NAME, PALETTE_OPTION_NAME, SIZE_OPTION_NAME } from "~/constants";
+import { savePrices } from "~/server/savePrices";
 
 export async function loader({ request, params }) {
   const { admin } = await authenticate.admin(request);
@@ -46,18 +48,19 @@ export async function action({ request, params }) {
   const data: SerializedCustomizeForm = JSON.parse(serializedData.get("data"));
 
 
-  // await savePrices(data.product, data.sizeToPrice, updatedSizes);
+  await savePrices(admin, data.product.id, data.product.variants.nodes,
+    data.sizeToPrice, data.sizeToPriceUpdates, data.flowerToPrice, data.flowerToPriceUpdates);
   return redirect(`/app`);
 }
 
-const createValueCustomizationsObject = (optionValues: string[]) => {
+const createValueCustomizationsObject = (optionValues: string[], optionValueToPrice: { [key: string]: number }) => {
   if (!optionValues) {
     return {};
   }
   return optionValues.reduce((acc: OptionValueCustomizations, value) => {
     acc[value] = {
       name: value,
-      price: 0, // TODO: get price from product variant
+      price: optionValueToPrice[value] != undefined ? optionValueToPrice[value] : 0, //todo: default prices
       connectedLeft: null
     };
     return acc;
@@ -106,21 +109,27 @@ export default function ByobCustomizationForm() {
   const formOptions: ByobCustomizerOptions = useLoaderData();
 
   const form: BouquetCustomizationForm = {
-    sizes: {
-      optionName: "Size",
-      optionValueCustomizations: createValueCustomizationsObject(formOptions.sizeOptions),
+    optionCustomizations: {
+      sizes: {
+        optionName: SIZE_OPTION_NAME,
+        optionValueCustomizations: createValueCustomizationsObject(formOptions.sizesSelected, formOptions.sizeToPrice),
+      },
+      palettes: {
+        optionName: PALETTE_OPTION_NAME,
+        optionValueCustomizations: createPaletteValueCustomizationsObject(
+          formOptions.palettesAvailable,
+          formOptions.palettesSelected
+        ),
+      },
+      flowers: {
+        optionName: FLOWER_OPTION_NAME,
+        optionValueCustomizations: createValueCustomizationsObject(formOptions.flowersSelected, formOptions.flowerToPrice),
+      }
     },
-    palettes: {
-      optionName: "Palette",
-      optionValueCustomizations: createPaletteValueCustomizationsObject(
-        formOptions.palettesAvailable,
-        formOptions.palettesSelected
-      ),
-    },
-    flowers: {
-      optionName: "Focal Flower",
-      optionValueCustomizations: createFlowerValueCustomizationsObject(formOptions.flowersAvailable, formOptions.flowersSelected),
-    }
+    sizeToPrice: formOptions.sizeToPrice,
+    sizeToPriceUpdates: {},
+    flowerToPrice: formOptions.flowerToPrice,
+    flowerToPriceUpdates: {}
   }
 
   const [formState, setFormState] = useState(form);
@@ -138,8 +147,17 @@ export default function ByobCustomizationForm() {
   // TODO: https://linear.app/foxtail-creates/issue/FOX-30/shopify-app-frontend-pricing
 
   function submitFormData() {
-    // todo
-    submit({}, { method: "post" });
+    const data: SerializedCustomizeForm = {
+      product: formOptions.customProduct,
+      sizeToPrice: formState.sizeToPrice,
+      sizeToPriceUpdates: formState.sizeToPriceUpdates,
+      flowerToPrice: formState.flowerToPrice,
+      flowerToPriceUpdates: formState.flowerToPriceUpdates,
+    };
+
+    const serializedData = JSON.stringify(data);
+
+    submit({ data: serializedData }, { method: "post" });
   }
 
   return (
@@ -180,9 +198,10 @@ export default function ByobCustomizationForm() {
                       </List>
                     </>
                   }
-                  optionCustomizations={form.sizes}
+                  optionCustomizations={form.optionCustomizations.sizes}
                   formState={formState}
                   setFormState={setFormState}
+                  optionValueToPriceUpdates={formState.sizeToPriceUpdates}
                 />
                 <Divider />
                 <CustomizationSection
@@ -202,9 +221,10 @@ export default function ByobCustomizationForm() {
                       </List>
                     </>
                   }
-                  optionCustomizations={form.palettes}
+                  optionCustomizations={form.optionCustomizations.palettes}
                   formState={formState}
                   setFormState={setFormState}
+                  optionValueToPriceUpdates={{}}
                 />
                 <Divider />
                 <CustomizationSection
@@ -227,9 +247,10 @@ export default function ByobCustomizationForm() {
                       </List>
                     </>
                   }
-                  optionCustomizations={form.flowers}
+                  optionCustomizations={form.optionCustomizations.flowers}
                   formState={formState}
                   setFormState={setFormState}
+                  optionValueToPriceUpdates={formState.flowerToPriceUpdates}
                 />
               </BlockStack>
             </Card>

--- a/app/server/createProductWithOptionsAndCreateVariants.ts
+++ b/app/server/createProductWithOptionsAndCreateVariants.ts
@@ -1,4 +1,4 @@
-import { FLOWER_OPTION_NAME, FLOWER_POSITION, SIZE_OPTION_NAME, SIZE_POSITION, PALETTE_OPTION_NAME, PALETTE_POSITION, FOXTAIL_NAMESPACE, PRODUCT_METADATA_PRICES, SIZE_TO_PRICE_DEFAULT_VALUES_SERIALIZED } from "~/constants";
+import { FLOWER_OPTION_NAME, FLOWER_POSITION, SIZE_OPTION_NAME, SIZE_POSITION, PALETTE_OPTION_NAME, PALETTE_POSITION, FOXTAIL_NAMESPACE, PRODUCT_METADATA_PRICES, SIZE_TO_PRICE_DEFAULT_VALUES_SERIALIZED, OPTION_TO_PRICE_DEFAULT_VALUES_SERIALIZED, SIZE_OPTION_VALUES, SIZE_TO_PRICE_DEFAULT_VALUES } from "~/constants";
 import { CREATE_PRODUCT_WITH_OPTIONS_QUERY } from "./graphql";
 import invariant from "tiny-invariant";
 import { createVariants } from "./createVariants";
@@ -7,7 +7,7 @@ import { createVariants } from "./createVariants";
  * Creates a new product
  */
 export async function createProductWithOptionsAndVariants(admin, selectedFlowers: string[],
-  selectedPalettes: string[], selectedSizes: string[], sizeToPrices: { [key: string]: number }) {
+  selectedPalettes: string[], selectedSizes: string[], sizeToPrice: { [key: string]: number }, flowerToPrice: { [key: string]: number }) {
     const customProductResponse = await admin.graphql(
       CREATE_PRODUCT_WITH_OPTIONS_QUERY,
       {
@@ -25,7 +25,7 @@ export async function createProductWithOptionsAndVariants(admin, selectedFlowers
           paletteValues: selectedPalettes.map((value: string) => ({ "name": value })),
           metafieldNamespace: FOXTAIL_NAMESPACE,
           metafieldKey: PRODUCT_METADATA_PRICES,
-          metafieldValue: SIZE_TO_PRICE_DEFAULT_VALUES_SERIALIZED
+          metafieldValue: OPTION_TO_PRICE_DEFAULT_VALUES_SERIALIZED
         },
       },
     );
@@ -36,6 +36,6 @@ export async function createProductWithOptionsAndVariants(admin, selectedFlowers
         "Error creating new product. Contact Support for help."
     );  
 
-    await createVariants(admin, customProductBody.data.productCreate.product.id, selectedFlowers, selectedSizes, selectedPalettes, sizeToPrices);
+    await createVariants(admin, customProductBody.data.productCreate.product.id, selectedFlowers, selectedSizes, selectedPalettes, sizeToPrice, flowerToPrice);
     return customProductBody.data.productCreate.product;
   }

--- a/app/server/createVariants.ts
+++ b/app/server/createVariants.ts
@@ -1,4 +1,4 @@
-import { FLOWER_OPTION_NAME, PALETTE_OPTION_NAME, SIZE_OPTION_NAME, SIZE_TO_PRICE_DEFAULT_VALUES } from "~/constants";
+import { DEFAULT_FLOWER_PRICE, FLOWER_OPTION_NAME, PALETTE_OPTION_NAME, SIZE_OPTION_NAME, SIZE_TO_PRICE_DEFAULT_VALUES } from "~/constants";
 import { CREATE_VARIANTS_QUERY } from "./graphql";
 import invariant from "tiny-invariant";
 
@@ -8,15 +8,19 @@ export async function createVariants(
     flowerValues: string[],
     sizeValues: string[],
     paletteValues: string[],
-    sizeToPrice: { [key: string]: number }
+    sizeToPrice: { [key: string]: number },
+    flowerToPrice: { [key: string]: number }
  ) {
     const variants = [];
     for (let f = 0; f < flowerValues.length; f++) {
         for (let s = 0; s < sizeValues.length; s++) {
             for(let p = 0; p < paletteValues.length; p++) {
-                const unitPrice = Object.prototype.hasOwnProperty.call(sizeToPrice, sizeValues[s])
-                    ?  sizeToPrice[sizeValues[s]].toString()
-                    : SIZE_TO_PRICE_DEFAULT_VALUES[sizeValues[s]].toString();
+                const sizePrice: number = Object.prototype.hasOwnProperty.call(sizeToPrice, sizeValues[s])
+                    ?  sizeToPrice[sizeValues[s]]
+                    : SIZE_TO_PRICE_DEFAULT_VALUES[sizeValues[s]]
+                const flowerPrice: number = Object.prototype.hasOwnProperty.call(flowerToPrice, flowerValues[f])
+                ?  flowerToPrice[flowerValues[s]]
+                : DEFAULT_FLOWER_PRICE
                 variants.push({
                     optionValues: [
                         {
@@ -32,7 +36,7 @@ export async function createVariants(
                             name: paletteValues[p]
                         }
                     ],
-                    price: unitPrice
+                    price: (sizePrice + flowerPrice).toString()
                 })
             }
             
@@ -54,4 +58,5 @@ export async function createVariants(
     invariant(createVariantsBody.data?.productVariantsBulkCreate.userErrors.length == 0,
         "Error creating new variant. Contact Support for help."
     );
+    return createVariantsBody.data.productVariantsBulkCreate.product;
 }

--- a/app/server/graphql/index.js
+++ b/app/server/graphql/index.js
@@ -3,6 +3,7 @@
  */
 export { CREATE_VARIANTS_QUERY } from "./queries/productVariant/createVariant";
 export { BULK_CREATE_VARIANTS_QUERY } from "./queries/productVariant/bulkCreateVariants";
+export { BULK_UPDATE_VARIANTS_QUERY } from "./queries/productVariant/bulkUpdateVariants";
 
 export { CREATE_PRODUCT_WITH_OPTIONS_QUERY } from "./queries/product/createProductWithOptions";
 export { SET_PRODUCT_METAFIELD_QUERY } from "./queries/product/setProductMetafield";

--- a/app/server/graphql/queries/product/createProductWithOptions.ts
+++ b/app/server/graphql/queries/product/createProductWithOptions.ts
@@ -26,8 +26,20 @@ export const CREATE_PRODUCT_WITH_OPTIONS_QUERY= `#graphql
                   name
                 }
               }
-              metafield (namespace: $metafieldNamespace, key: $metafieldKey) {
-                value
+              variants(first:100) { # TODO: limit number of variants/pagination
+                nodes {
+                  displayName
+                  id
+                  price
+                  selectedOptions {
+                    name
+                    optionValue {
+                      id
+                      name
+                    }
+                    value
+                  }
+                }
               }
             }
             userErrors {

--- a/app/server/graphql/queries/product/getProductById.ts
+++ b/app/server/graphql/queries/product/getProductById.ts
@@ -11,6 +11,21 @@ export const GET_PRODUCT_BY_ID_QUERY = `#graphql
             name
           }
         }
+        variants(first:100) { # TODO: limit number of variants/pagination
+          nodes {
+            displayName
+            id
+            price
+            selectedOptions {
+              name
+              optionValue {
+                id
+                name
+              }
+              value
+            }
+          }
+        }
         metafield (namespace: $namespace, key: $key) {
           value
         }

--- a/app/server/graphql/queries/productOption/createProductOptions.ts
+++ b/app/server/graphql/queries/productOption/createProductOptions.ts
@@ -5,6 +5,33 @@ export const CREATE_PRODUCT_OPTIONS_QUERY = `#graphql
             position: $position,
             values: $values
         }) {
+            product {
+              id
+              options {
+                id
+                name
+                position
+                optionValues {
+                  id
+                  name
+                }
+              }
+              variants(first:100) { # TODO: handle large amounts of variants. Make product projection into a fragment
+                nodes {
+                  displayName
+                  id
+                  price
+                  selectedOptions {
+                    name
+                    optionValue {
+                      id
+                      name
+                    }
+                    value
+                  }
+                }
+              }
+            }
             userErrors{
                 field
                 message

--- a/app/server/graphql/queries/productOption/updateProductOptionAndVariants.ts
+++ b/app/server/graphql/queries/productOption/updateProductOptionAndVariants.ts
@@ -11,26 +11,30 @@ export const UPDATE_PRODUCT_OPTION_AND_VARIANTS_QUERY = `#graphql
         ) {
             product {
                 id
-                options(first: 5) {
-                    name
-                    optionValues {
-                    name
-                    }
-                }
-                variants(first: 5) {
-                    nodes {
+                options {
+                id
+                name
+                position
+                optionValues {
                     id
+                    name
+                }
+                }
+                variants(first:100) { # TODO: limit number of variants/pagination
+                nodes {
                     displayName
+                    id
+                    price
                     selectedOptions {
-                        name
-                        value
-                        optionValue {
+                    name
+                    optionValue {
                         id
                         name
-                        }
                     }
+                    value
                     }
                 }
+            }
             }
             userErrors {
                 field

--- a/app/server/graphql/queries/productVariant/bulkCreateVariants.ts
+++ b/app/server/graphql/queries/productVariant/bulkCreateVariants.ts
@@ -7,23 +7,27 @@ export const BULK_CREATE_VARIANTS_QUERY = `#graphql
         ) {
         product {
             id
-            options(first: 5) {
+            options {
+            id
             name
+            position
             optionValues {
+                id
                 name
             }
             }
-            variants(first: 5) {
+            variants(first:100) { # TODO: limit number of variants/pagination
             nodes {
-                id
                 displayName
+                id
+                price
                 selectedOptions {
                 name
-                value
                 optionValue {
                     id
                     name
                 }
+                value
                 }
             }
             }

--- a/app/server/graphql/queries/productVariant/bulkUpdateVariants.ts
+++ b/app/server/graphql/queries/productVariant/bulkUpdateVariants.ts
@@ -4,6 +4,33 @@ export const BULK_UPDATE_VARIANTS_QUERY = `#graphql
       productId: $productId
       variants: $variantsToBulkUpdate
     ) {
+      product {
+        id
+        options {
+          id
+          name
+          position
+          optionValues {
+            id
+            name
+          }
+        }
+        variants(first:100) { # TODO: limit number of variants/pagination
+          nodes {
+            displayName
+            id
+            price
+            selectedOptions {
+              name
+              optionValue {
+                id
+                name
+              }
+              value
+            }
+          }
+        }
+      }
       userErrors {
         field
         message

--- a/app/server/graphql/queries/productVariant/createVariant.ts
+++ b/app/server/graphql/queries/productVariant/createVariant.ts
@@ -1,6 +1,33 @@
 export const CREATE_VARIANTS_QUERY = `#graphql
     mutation createVariants($variants: [ProductVariantsBulkInput!]!, $productId: ID!) {
         productVariantsBulkCreate(variants: $variants, productId: $productId, strategy: REMOVE_STANDALONE_VARIANT) {
+          product {
+              id
+              options {
+                id
+                name
+                position
+                optionValues {
+                  id
+                  name
+                }
+              }
+              variants(first:100) { # TODO: limit number of variants/pagination
+                nodes {
+                  displayName
+                  id
+                  price
+                  selectedOptions {
+                    name
+                    optionValue {
+                      id
+                      name
+                    }
+                    value
+                  }
+                }
+              }
+            }
             userErrors {
                 message
                 field

--- a/app/server/savePrices.ts
+++ b/app/server/savePrices.ts
@@ -1,0 +1,30 @@
+import { FOXTAIL_NAMESPACE, PRODUCT_METADATA_PRICES } from "~/constants";
+import { updateVariants } from "./updateVariants";
+import { setProductMetadata } from "./setProductMetadata";
+
+export async function savePrices(
+    admin,
+    productId: string,
+    variantNodes,
+    sizeToPrice: { [key:string]: number },
+    sizeToPriceUpdates: { [key:string]: number },
+    flowerToPrice: { [key:string]: number },
+    flowerToPriceUpdates: { [key:string]: number }
+) {
+
+    await updateVariants(admin, productId, variantNodes, sizeToPrice, sizeToPriceUpdates, flowerToPrice, flowerToPriceUpdates);
+
+    updatePriceMap(sizeToPrice, sizeToPriceUpdates);
+    updatePriceMap(flowerToPrice, flowerToPriceUpdates);
+
+    // use the updated prices to save in the product price metadata maps
+    await setProductMetadata(admin, productId,
+        FOXTAIL_NAMESPACE, PRODUCT_METADATA_PRICES, JSON.stringify({sizeToPrice: sizeToPrice, flowerToPrice: flowerToPrice}));
+    
+}
+
+export function updatePriceMap(original: { [key:string]: number }, updates: { [key:string]: number }) {
+    for (const optionValue in updates) {
+        original[optionValue] = updates[optionValue];
+    }
+}

--- a/app/server/updateOptionsAndCreateVariants.ts
+++ b/app/server/updateOptionsAndCreateVariants.ts
@@ -10,7 +10,7 @@ export async function updateOptionsAndCreateVariants(
     optionValuesToRemove: string[],
     optionValuesToAdd: string[],
     optionValuesSelected: string[]
- ) {
+) {
     const option = product.options.find(
         (o) => o.name === optionName,
     );

--- a/app/server/updateVariants.ts
+++ b/app/server/updateVariants.ts
@@ -1,0 +1,59 @@
+import { DEFAULT_FLOWER_PRICE, FLOWER_OPTION_NAME, SIZE_OPTION_NAME, SIZE_TO_PRICE_DEFAULT_VALUES } from "~/constants";
+import { BULK_UPDATE_VARIANTS_QUERY } from "./graphql/queries/productVariant/bulkUpdateVariants";
+
+export async function updateVariants(
+    admin,
+    productId: string,
+    variantNodes,
+    sizeToPrice: { [key:string]: number},
+    sizeToPriceUpdates: { [key:string]: number},
+    flowerToPrice: { [key:string]: number},
+    flowerToPriceUpdates: { [key:string]: number}
+ ) {
+    const newVariants = [];
+    // for all variants, if flower or size options are in the update maps, recalculate price
+    variantNodes.forEach( (variantNode) => {
+        const sizeName: string = variantNode.selectedOptions.find((option) => option.name == SIZE_OPTION_NAME).value;
+        const shouldUpdateSizePrice: boolean = Object.prototype.hasOwnProperty.call(sizeToPriceUpdates, sizeName);
+        const defaultSizePrice: number = Object.prototype.hasOwnProperty.call(sizeToPrice, sizeName)
+            ? sizeToPrice[sizeName]
+            : SIZE_TO_PRICE_DEFAULT_VALUES[sizeName];
+
+        const flowerName: string = variantNode.selectedOptions.find((option) => option.name == FLOWER_OPTION_NAME).value;
+        const shouldUpdateFlowerPrice: boolean = Object.prototype.hasOwnProperty.call(flowerToPriceUpdates, flowerName);
+        const defaultFlowerPrice: number = Object.prototype.hasOwnProperty.call(flowerToPrice, flowerName)
+            ? flowerToPrice[flowerName]
+            : DEFAULT_FLOWER_PRICE;
+
+        if (shouldUpdateSizePrice || shouldUpdateFlowerPrice) {
+            const sizePrice = shouldUpdateSizePrice ? sizeToPriceUpdates[sizeName] : defaultSizePrice;
+            const flowerPrice = shouldUpdateFlowerPrice ? flowerToPriceUpdates[flowerName] : defaultFlowerPrice;
+            newVariants.push({
+                id: variantNode.id,
+                price: (sizePrice + flowerPrice).toString()
+            })
+        }   
+    });
+    
+
+    const updateVariantsResponse = await admin.graphql(
+        BULK_UPDATE_VARIANTS_QUERY,
+        {
+            variables: {
+                productId: productId,
+                variantsToBulkUpdate: newVariants
+            }
+        }
+    );
+    const updateVariantsBody = await updateVariantsResponse.json();
+
+    const hasErrors: boolean = updateVariantsBody.data?.productVariantsBulkUpdate.userErrors.length != 0;
+    if (hasErrors) {
+        console.log("Error updating variants. Message {"
+            + updateVariantsBody.data?.productVariantsBulkUpdate.userErrors[0].message
+            + "} on field {"
+            + updateVariantsBody.data?.productVariantsBulkUpdate.userErrors[0].field
+            + "}");
+        throw "Error updating variants. Contact Support for help.";
+    }
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -13,6 +13,8 @@ export type ByobCustomizerOptions = {
   palettesSelected: string[];
   flowersAvailable: Flower[];
   flowersSelected: string[];
+  sizeToPrice: { [key: string]: number };
+  flowerToPrice: { [key: string]: number };
 };
 
 export type BouquetSettingsForm = {
@@ -52,7 +54,9 @@ export type SerializedSettingForm = {
 export type SerializedCustomizeForm = {
   product: Product;
   sizeToPrice: { [key: string]: number };
-  updatedSizes: string[];
+  sizeToPriceUpdates: { [key: string]: number };
+  flowerToPrice: { [key: string]: number };
+  flowerToPriceUpdates: { [key: string]: number };
 }
 
 export type FocalFlowersSectionProps = {
@@ -97,7 +101,11 @@ export type BouquetCustomizationOptions = {
 };
 
 export type BouquetCustomizationForm = {
-  [key: string]: OptionCustomization;
+  optionCustomizations: { [key: string]: OptionCustomization };
+  sizeToPrice: { [key: string]: number };
+  sizeToPriceUpdates: { [key: string]: number };
+  flowerToPrice: { [key: string]: number };
+  flowerToPriceUpdates: { [key: string]: number };
 };
 
 export type OptionCustomization = {
@@ -123,7 +131,13 @@ export type CustomizationProps = {
   shouldSetName: boolean;
   shouldSortOptions: boolean;
   instructions: ReactElement | null;
-  optionCustomizations: OptionCustomization
+  optionCustomizations: OptionCustomization;
   formState: BouquetCustomizationForm;
+  optionValueToPriceUpdates: { [key: string]: number };
   setFormState: Dispatch<SetStateAction<BouquetCustomizationForm>>;
+}
+
+export type PriceMetadata = {
+  sizeToPrice: { [key: string]: number };
+  flowerToPrice: { [key: string]: number };
 }

--- a/shopify.app.foxtail-designs.toml
+++ b/shopify.app.foxtail-designs.toml
@@ -3,7 +3,7 @@
 client_id = "276741cc496195767e491f77bc719d46"
 name = "foxtail-designs"
 handle = "foxtail-designs-1"
-application_url = "https://porsche-michel-lay-def.trycloudflare.com"
+application_url = "https://reuters-hh-newman-exception.trycloudflare.com"
 embedded = true
 
 [build]
@@ -17,9 +17,9 @@ scopes = "read_products,write_products"
 
 [auth]
 redirect_urls = [
-  "https://porsche-michel-lay-def.trycloudflare.com/auth/callback",
-  "https://porsche-michel-lay-def.trycloudflare.com/auth/shopify/callback",
-  "https://porsche-michel-lay-def.trycloudflare.com/api/auth/callback"
+  "https://reuters-hh-newman-exception.trycloudflare.com/auth/callback",
+  "https://reuters-hh-newman-exception.trycloudflare.com/auth/shopify/callback",
+  "https://reuters-hh-newman-exception.trycloudflare.com/api/auth/callback"
 ]
 
 [webhooks]


### PR DESCRIPTION
- add flower price support
- Save new prices from form by updating variant prices and setting product metadata
- project same fields for product across graphql queries. This should be moved to a fragment