### PR TITLE
Fix bug where selection does not match new product variants

### DIFF
--- a/app/server/createProductWithOptionsAndCreateVariants.ts
+++ b/app/server/createProductWithOptionsAndCreateVariants.ts
@@ -7,7 +7,7 @@ import { createVariants } from "./createVariants";
  */
 export async function createProductWithOptionsAndVariants(admin, selectedFlowers: string[], optionToName: { [key: string]: string},
   selectedPalettes: string[], selectedSizes: string[], sizeToPrice: { [key: string]: number }, flowerToPrice: { [key: string]: number }) {
-    const customProductResponse = await admin.graphql(
+    const customProductWithOptionsResponse = await admin.graphql(
       CREATE_PRODUCT_WITH_OPTIONS_QUERY,
       {
         variables: {
@@ -29,18 +29,18 @@ export async function createProductWithOptionsAndVariants(admin, selectedFlowers
       },
     );
 
-    const customProductBody = await customProductResponse.json();
+    const customProductWithOptionsBody = await customProductWithOptionsResponse.json();
 
-    const hasErrors: boolean = customProductBody.data?.productCreate.userErrors.length != 0;
+    const hasErrors: boolean = customProductWithOptionsBody.data?.productCreate.userErrors.length != 0;
     if (hasErrors) {
         console.log("Error creating new product. Message {"
-            + customProductBody.data?.productCreate.userErrors[0].message
+            + customProductWithOptionsBody.data?.productCreate.userErrors[0].message
             + "} on field {"
-            + customProductBody.data?.productCreate.userErrors[0].field
+            + customProductWithOptionsBody.data?.productCreate.userErrors[0].field
             + "}");
         throw "Error creating new product. Contact Support for help.";
     }
 
-    await createVariants(admin, customProductBody.data.productCreate.product.id, selectedFlowers, selectedSizes, selectedPalettes, sizeToPrice, flowerToPrice, optionToName);
-    return customProductBody.data.productCreate.product;
+    const customProductWithVariants = await createVariants(admin, customProductWithOptionsBody.data.productCreate.product.id, selectedFlowers, selectedSizes, selectedPalettes, sizeToPrice, flowerToPrice, optionToName);
+    return customProductWithVariants;
   }

--- a/shopify.app.foxtail-designs.toml
+++ b/shopify.app.foxtail-designs.toml
@@ -3,7 +3,7 @@
 client_id = "276741cc496195767e491f77bc719d46"
 name = "foxtail-designs"
 handle = "foxtail-designs-1"
-application_url = "https://leone-fusion-magnitude-hs.trycloudflare.com"
+application_url = "https://answer-effect-clan-brakes.trycloudflare.com"
 embedded = true
 
 [build]
@@ -17,9 +17,9 @@ scopes = "read_products,write_products"
 
 [auth]
 redirect_urls = [
-  "https://leone-fusion-magnitude-hs.trycloudflare.com/auth/callback",
-  "https://leone-fusion-magnitude-hs.trycloudflare.com/auth/shopify/callback",
-  "https://leone-fusion-magnitude-hs.trycloudflare.com/api/auth/callback"
+  "https://answer-effect-clan-brakes.trycloudflare.com/auth/callback",
+  "https://answer-effect-clan-brakes.trycloudflare.com/auth/shopify/callback",
+  "https://answer-effect-clan-brakes.trycloudflare.com/api/auth/callback"
 ]
 
 [webhooks]


### PR DESCRIPTION
After deleting a product and creating a new product, I noticed form selection was showing empty selections on the "Settings" page. This is because the default selections are used for creating the product, while the "previous selections" are used for displaying current selected options. 