### PR TITLE
save custom size values

### DIFF
--- a/app/components/customizations/CustomizationSection.tsx
+++ b/app/components/customizations/CustomizationSection.tsx
@@ -1,6 +1,6 @@
 import { InlineGrid, InlineStack, TextField } from "@shopify/polaris";
 import { useCallback } from "react";
-import { FLOWER_CUSTOMIZATION_SECTION_NAME, SIZE_CUSTOMIZATION_SECTION_NAME } from "~/constants";
+import { FLOWER_CUSTOMIZATION_SECTION_NAME, PALETTE_OPTION_NAME, SIZE_CUSTOMIZATION_SECTION_NAME, SIZE_OPTION_NAME } from "~/constants";
 import type { BouquetCustomizationForm, CustomizationProps, ValueCustomization } from "~/types";
 
 
@@ -55,12 +55,22 @@ const CustomizationOptions = (props: CustomizationOptionsProps) => {
 
   const updateOptionValueName = useCallback(
     (value: string) => {
+      let customValueName: string | null = null;
+      if ((optionKey) === PALETTE_OPTION_NAME) {
+        customValueName = "paletteToNameUpdates";
+      } else if ((optionKey) === SIZE_OPTION_NAME) {
+        customValueName = "sizeToNameUpdates";
+      }
       setFormState({
         ...formState,
-        paletteToNameUpdates: {
-          ...formState.paletteToNameUpdates,
-          [optionValueKey]: value
-        },
+        ...(customValueName != null &&
+          {
+            [customValueName]: {
+              ...formState[customValueName],
+              [optionValueKey]: value
+            }
+          }
+        ),
         optionCustomizations: {
           ...formState.optionCustomizations,
           [optionKey]: {

--- a/app/components/sizes/SizeSection.tsx
+++ b/app/components/sizes/SizeSection.tsx
@@ -32,6 +32,12 @@ export const SizeSection = ({
       : null;
   }
 
+
+  function getDisplayName(sizeEnum: string) {
+    return formState.sizeEnumToName.customMap[sizeEnum] != null
+      ? formState.sizeEnumToName.customMap[sizeEnum]
+      : formState.sizeEnumToName.defaultMap[sizeEnum]
+  }
   return (
     <>
       <Text as={"h3"} variant="headingMd">
@@ -41,7 +47,7 @@ export const SizeSection = ({
         title="Choose what bouquet sizes you want to offer."
         allowMultiple
         choices={allSizesAvailable.map((option) => {
-          return { label: option, value: option };
+          return { label: getDisplayName(option), value: option };
         })}
         selected={formState.sizesSelected}
         onChange={handleChange}

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,4 +1,5 @@
 import { ProductMetadata } from "./types";
+import { Size } from "./size";
 
 export const FOXTAIL_NAMESPACE = "foxtail";
 export const STORE_METADATA_CUSTOM_PRODUCT_KEY = "customProductId";
@@ -21,23 +22,27 @@ export const PALETTE_CUSTOMIZATION_SECTION_NAME = "palettes";
 export const SIZE_CUSTOMIZATION_SECTION_NAME = "sizes";
 
 // default size values in different forms
-export const SIZE_OPTION_VALUES = ["Small", "Medium", "Large", "Extra-Large"];
-export const SIZE_TO_PRICE_DEFAULT_VALUES: {[key: string]: number} = {
-    "Small": 40,
-    "Medium": 50,
-    "Large": 60,
-    "Extra-Large": 70
+export const SIZE_OPTION_VALUES = Object.values(Size);
+
+export const SIZE_TO_PRICE_DEFAULT_VALUES: { [key: string]: number } = {
+    [Size.SMALL]: 40,
+    [Size.MEDIUM]: 50,
+    [Size.LARGE]: 60,
+    [Size.EXTRA_LARGE]: 70
 };
 
+export const SIZE_TO_NAME_DEFAULT_VALUES: { [key: string]: string } = Object.fromEntries(
+    SIZE_OPTION_VALUES.map(s => [s, s])
+);
 
 export const SIZE_TO_PRICE_DEFAULT_VALUES_SERIALIZED = JSON.stringify(SIZE_TO_PRICE_DEFAULT_VALUES);
 
 // default flower price values
 export const DEFAULT_FLOWER_PRICE = 0;
 
-export const FLOWER_TO_PRICE_DEFAULT_VALUES: {[key: string]: number} = {};
+export const FLOWER_TO_PRICE_DEFAULT_VALUES: { [key: string]: number } = {};
 
-export const OPTION_TO_NAME_DEFAULT_VALUES: {[key: string]: string} = {
+export const OPTION_TO_NAME_DEFAULT_VALUES: { [key: string]: string } = {
     [FLOWER_OPTION_NAME]: FLOWER_OPTION_NAME,
     [PALETTE_OPTION_NAME]: PALETTE_OPTION_NAME,
     [SIZE_OPTION_NAME]: SIZE_OPTION_NAME
@@ -48,7 +53,8 @@ export const PRODUCT_METADATA_DEFAULT_VALUES: ProductMetadata = {
     sizeToPrice: SIZE_TO_PRICE_DEFAULT_VALUES,
     flowerToPrice: FLOWER_TO_PRICE_DEFAULT_VALUES,
     optionToName: OPTION_TO_NAME_DEFAULT_VALUES,
-    paletteToName: {}
+    paletteToName: {},
+    sizeToName: {}
 };
 
 export const PRODUCT_METADATA_DEFAULT_VALUES_SERIALIZED = JSON.stringify(PRODUCT_METADATA_DEFAULT_VALUES);

--- a/app/routes/app.bouquets.customize.tsx
+++ b/app/routes/app.bouquets.customize.tsx
@@ -57,6 +57,24 @@ export async function action({ request, params }) {
 }
 
 
+const createSizeValueCustomizationsObject = (sizeEnumsAvailable: string[], selectedSizeEnums: string[],
+  sizeEnumToPrice: { [key: string]: number }, sizeEnumToName: SerializedTwoWayFallbackMap) => {
+  if (!selectedSizeEnums) {
+    return {};
+  }
+  const rv = {};
+  sizeEnumsAvailable.forEach((sizeEnum) => {
+    if (selectedSizeEnums.includes(sizeEnum)) {
+      rv[sizeEnum] = {
+        name: TwoWayFallbackMap.getValue(sizeEnum, sizeEnumToName.customMap, sizeEnumToName.defaultMap),
+        price: sizeEnumToPrice[sizeEnum] != undefined ? sizeEnumToPrice[sizeEnum] : 0,
+        connectedLeft: null
+      }
+    }
+  });
+  return rv;
+}
+
 const createValueCustomizationsObject = (optionValues: string[], optionValueToPrice: { [key: string]: number }) => {
   if (!optionValues) {
     return {};
@@ -64,7 +82,7 @@ const createValueCustomizationsObject = (optionValues: string[], optionValueToPr
   return optionValues.reduce((acc: OptionValueCustomizations, value) => {
     acc[value] = {
       name: value,
-      price: optionValueToPrice[value] != undefined ? optionValueToPrice[value] : 0, //todo: default prices
+      price: optionValueToPrice[value] != undefined ? optionValueToPrice[value] : 0,
       connectedLeft: null
     };
     return acc;
@@ -116,7 +134,12 @@ export default function ByobCustomizationForm() {
     optionCustomizations: {
       [SIZE_OPTION_NAME]: {
         optionName: formOptions.productMetadata.optionToName[SIZE_OPTION_NAME],
-        optionValueCustomizations: createValueCustomizationsObject(formOptions.sizesSelected, formOptions.productMetadata.sizeToPrice),
+        optionValueCustomizations: createSizeValueCustomizationsObject(
+          formOptions.sizesAvailable,
+          formOptions.sizesSelected,
+          formOptions.productMetadata.sizeToPrice,
+          formOptions.sizeEnumToName
+        ),
       },
       [PALETTE_OPTION_NAME]: {
         optionName: formOptions.productMetadata.optionToName[PALETTE_OPTION_NAME],
@@ -136,6 +159,7 @@ export default function ByobCustomizationForm() {
     sizeToPriceUpdates: {},
     flowerToPriceUpdates: {},
     paletteToNameUpdates: {},
+    sizeToNameUpdates: {}
   }
 
   const [formState, setFormState] = useState(form);
@@ -157,7 +181,9 @@ export default function ByobCustomizationForm() {
       flowerToPriceUpdates: formState.flowerToPriceUpdates,
       optionToNameUpdates: formState.optionToNameUpdates,
       paletteToNameUpdates: formState.paletteToNameUpdates,
-      paletteBackendIdToName: formOptions.paletteBackendIdToName
+      paletteBackendIdToName: formOptions.paletteBackendIdToName,
+      sizeToNameUpdates: formState.sizeToNameUpdates,
+      sizeEnumToName: formOptions.sizeEnumToName
     };
 
     const serializedData = JSON.stringify(data);

--- a/app/routes/app.bouquets.settings.tsx
+++ b/app/routes/app.bouquets.settings.tsx
@@ -72,7 +72,7 @@ export async function action({ request, params }) {
   await updateOptionsAndCreateVariants(admin, data.product, data.productMetadata.optionToName[FLOWER_OPTION_NAME], FLOWER_POSITION, data.flowerOptionValuesToRemove, data.flowerOptionValuesToAdd,
     data.flowersSelected, (x) => x);
   await updateOptionsAndCreateVariants(admin, data.product, data.productMetadata.optionToName[SIZE_OPTION_NAME], SIZE_POSITION, data.sizeOptionValuesToRemove, data.sizeOptionValuesToAdd,
-    data.sizesSelected, (x) => x);
+    data.sizesSelected, (sizeEnum) => TwoWayFallbackMap.getValue(sizeEnum, data.sizeEnumToName.customMap, data.sizeEnumToName.defaultMap));
   await updateOptionsAndCreateVariants(admin, data.product, data.productMetadata.optionToName[PALETTE_OPTION_NAME], PALETTE_POSITION, data.paletteOptionValuesToRemove, data.paletteOptionValuesToAdd,
     data.palettesSelected, (paletteId => TwoWayFallbackMap.getValue(paletteId, data.paletteBackendIdToName.customMap, data.paletteBackendIdToName.defaultMap)));
 
@@ -91,6 +91,7 @@ export default function ByobCustomizationForm() {
     allSizeOptions: byobCustomizer.sizesAvailable,
     sizeOptionValuesToAdd: [],
     sizeOptionValuesToRemove: [],
+    sizeEnumToName: byobCustomizer.sizeEnumToName,
     allPaletteColorOptions: byobCustomizer.palettesAvailable.map(
       (palette) => palette.name,
     ),
@@ -124,6 +125,7 @@ export default function ByobCustomizationForm() {
       sizesSelected: formState.sizesSelected,
       sizeOptionValuesToAdd: formState.sizeOptionValuesToAdd,
       sizeOptionValuesToRemove: formState.sizeOptionValuesToRemove,
+      sizeEnumToName: formState.sizeEnumToName,
       allPaletteColorOptions: formState.allPaletteColorOptions,
       palettesSelected: formState.palettesSelected,
       paletteOptionValuesToRemove: formState.paletteOptionValuesToRemove,

--- a/app/server/createVariants.ts
+++ b/app/server/createVariants.ts
@@ -12,7 +12,8 @@ export async function createVariants(
     sizeToPrice: { [key: string]: number },
     flowerToPrice: { [key: string]: number },
     optionToName: { [key: string]: string },
-    backendIdToName: TwoWayFallbackMap
+    paletteBackendIdToName: TwoWayFallbackMap,
+    sizeEnumToName: TwoWayFallbackMap
  ) {
     const variants = [];
     for (let f = 0; f < flowerValues.length; f++) {
@@ -32,11 +33,11 @@ export async function createVariants(
                         },
                         {
                             optionName: optionToName[SIZE_OPTION_NAME],
-                            name: sizeValues[s]
+                            name: sizeEnumToName.getValue(sizeValues[s])
                         },
                         {
                             optionName: optionToName[PALETTE_OPTION_NAME],
-                            name: backendIdToName.getValue(paletteValues[p])
+                            name: paletteBackendIdToName.getValue(paletteValues[p])
                         }
                     ],
                     price: (sizePrice + flowerPrice).toString()

--- a/app/server/getBYOBOptions.ts
+++ b/app/server/getBYOBOptions.ts
@@ -1,4 +1,4 @@
-import { FLOWER_OPTION_NAME, FLOWER_POSITION, FLOWER_TO_PRICE_DEFAULT_VALUES, FOXTAIL_NAMESPACE, PRODUCT_METADATA_DEFAULT_VALUES_SERIALIZED, PALETTE_OPTION_NAME, PALETTE_POSITION, PRODUCT_METADATA_PRICES, SIZE_OPTION_NAME, SIZE_OPTION_VALUES, SIZE_POSITION, SIZE_TO_PRICE_DEFAULT_VALUES, STORE_METADATA_CUSTOM_PRODUCT_KEY, PRODUCT_METADATA_DEFAULT_VALUES } from "~/constants";
+import { FLOWER_OPTION_NAME, FLOWER_POSITION, FLOWER_TO_PRICE_DEFAULT_VALUES, FOXTAIL_NAMESPACE, PRODUCT_METADATA_DEFAULT_VALUES_SERIALIZED, PALETTE_OPTION_NAME, PALETTE_POSITION, PRODUCT_METADATA_PRICES, SIZE_OPTION_NAME, SIZE_OPTION_VALUES, SIZE_POSITION, SIZE_TO_PRICE_DEFAULT_VALUES, STORE_METADATA_CUSTOM_PRODUCT_KEY, PRODUCT_METADATA_DEFAULT_VALUES, SIZE_TO_NAME_DEFAULT_VALUES } from "~/constants";
 import type {
   ByobCustomizerOptions,
   ProductMetadata,
@@ -27,11 +27,11 @@ export async function getBYOBOptions(admin): Promise<ByobCustomizerOptions> {
   let sizesSelected = SIZE_OPTION_VALUES;  
   let palettesSelected: string[] = [firstPalette.id.toString()];
 
-  const backendIdToDefaultName: Record<string, string> = {};
-
+  const paletteBackendIdToDefaultName: Record<string, string> = {};
   allCustomOptions.palettesAvailable.forEach((palette) => {
-    backendIdToDefaultName[palette.id] = palette.name;
+    paletteBackendIdToDefaultName[palette.id] = palette.name;
   });
+  const sizeEnumToDefaultName: Record<string, string> = SIZE_TO_NAME_DEFAULT_VALUES;
 
   const getShopMetadataResponse = await admin.graphql(
     GET_SHOP_METAFIELD_BY_KEY_QUERY,
@@ -46,7 +46,9 @@ export async function getBYOBOptions(admin): Promise<ByobCustomizerOptions> {
   let customProduct;
 
   const productMetadata: ProductMetadata = PRODUCT_METADATA_DEFAULT_VALUES;
-  let backendIdToName: TwoWayFallbackMap= new TwoWayFallbackMap({}, backendIdToDefaultName);
+  let paletteBackendIdToName: TwoWayFallbackMap= new TwoWayFallbackMap({}, paletteBackendIdToDefaultName);
+  let sizeEnumToName: TwoWayFallbackMap= new TwoWayFallbackMap({}, sizeEnumToDefaultName);
+
   const productId = shopMetadataBody.data?.shop.metafield?.value
   if (productId) {
     // if shop metadata has custom product id, retrieve it
@@ -65,7 +67,7 @@ export async function getBYOBOptions(admin): Promise<ByobCustomizerOptions> {
     if (customProduct == null) {
       // if custom product is missing, create new custom product and add to store metadata
       customProduct = await createProductWithOptionsAndVariants(admin, flowersSelected, productMetadata.optionToName, palettesSelected, sizesSelected, SIZE_TO_PRICE_DEFAULT_VALUES, FLOWER_TO_PRICE_DEFAULT_VALUES,
-        backendIdToName);
+        paletteBackendIdToName);
       await setShopMetafield(admin, shopMetadataBody.data?.shop.id, customProduct.id);
     }
 
@@ -74,7 +76,8 @@ export async function getBYOBOptions(admin): Promise<ByobCustomizerOptions> {
       for (const key in savedMetadata) {
         productMetadata[key] = savedMetadata[key];
       }
-      backendIdToName = new TwoWayFallbackMap(productMetadata.paletteToName, backendIdToDefaultName);
+      paletteBackendIdToName = new TwoWayFallbackMap(productMetadata.paletteToName, paletteBackendIdToDefaultName);
+      sizeEnumToName = new TwoWayFallbackMap(productMetadata.sizeToName, sizeEnumToDefaultName);
 
     } else {
       // if product metafield is missing for pricing, set metafield to default values
@@ -99,18 +102,18 @@ export async function getBYOBOptions(admin): Promise<ByobCustomizerOptions> {
       (option) => option.name === paletteDisplayName,
     );
     flowersSelected = await getSelectedValues(admin, flowerOption, customProduct, FLOWER_POSITION, flowerDisplayName, flowersSelected);
-    sizesSelected = await getSelectedValues(admin, sizeOption, customProduct, SIZE_POSITION, sizeDisplayName, SIZE_OPTION_VALUES);
-    palettesSelected = await getSelectedCustomValues(admin, paletteOption, customProduct, PALETTE_POSITION, paletteDisplayName, palettesSelected, backendIdToName);
+    sizesSelected = await getSelectedCustomValues(admin, sizeOption, customProduct, SIZE_POSITION, sizeDisplayName, SIZE_OPTION_VALUES, sizeEnumToName);
+    palettesSelected = await getSelectedCustomValues(admin, paletteOption, customProduct, PALETTE_POSITION, paletteDisplayName, palettesSelected, paletteBackendIdToName);
 
     if (sizeOption == null || flowerOption == null || paletteOption == null) {
       // if option previously had no selections, create variants using new default selections
       customProduct = await createVariants(admin, customProduct.id, flowersSelected, sizesSelected, palettesSelected, productMetadata.sizeToPrice, productMetadata.flowerToPrice,
-        productMetadata.optionToName, backendIdToName);
+        productMetadata.optionToName, paletteBackendIdToName, sizeEnumToName);
     }
   } else {
     // otherwise create new custom product and add to store metadata
     customProduct = await createProductWithOptionsAndVariants(admin, flowersSelected, productMetadata.optionToName, palettesSelected, SIZE_OPTION_VALUES, SIZE_TO_PRICE_DEFAULT_VALUES, FLOWER_TO_PRICE_DEFAULT_VALUES,
-      backendIdToName);
+      paletteBackendIdToName);
     await setShopMetafield(admin, shopMetadataBody.data?.shop.id, customProduct.id);
   }
 
@@ -120,12 +123,13 @@ export async function getBYOBOptions(admin): Promise<ByobCustomizerOptions> {
     customProduct: customProduct,
     sizesSelected: sizesSelected,
     sizesAvailable: SIZE_OPTION_VALUES,
+    sizeEnumToName: sizeEnumToName,
     palettesAvailable: allCustomOptions.palettesAvailable,
     palettesSelected: palettesSelected,
-    paletteBackendIdToName: backendIdToName,
+    paletteBackendIdToName: paletteBackendIdToName,
     flowersAvailable: allCustomOptions.flowersAvailable,
     flowersSelected: flowersSelected,
-    productMetadata: productMetadata
+    productMetadata: productMetadata,
   };
   return byobOptions;
 };

--- a/app/server/sanitizeData.ts
+++ b/app/server/sanitizeData.ts
@@ -4,6 +4,9 @@ export function sanitizeData(data: SerializedCustomizeForm) {
   for (const key in data.paletteToNameUpdates) {
     data.paletteToNameUpdates[key] = data.paletteToNameUpdates[key].trim();
   }
+  for (const key in data.sizeToNameUpdates) {
+    data.sizeToNameUpdates[key] = data.sizeToNameUpdates[key].trim();
+  }
   for (const key in data.optionToNameUpdates) {
     data.optionToNameUpdates[key] = data.optionToNameUpdates[key].trim();
   }

--- a/app/types.ts
+++ b/app/types.ts
@@ -9,11 +9,11 @@ export type ByobCustomizerOptions = {
   productName: string;
   customProduct: Product;
   sizesAvailable: string[];
-  sizesSelected: string[];
+  sizesSelected: string[]; // enums of sizes selected
   palettesAvailable: Palette[];
   palettesSelected: string[]; // backend ids of palettes, as strings
   paletteBackendIdToName: TwoWayFallbackMap;
-  sizeBackendIdToName: TwoWayFallbackMap;
+  sizeEnumToName: TwoWayFallbackMap;
   flowersAvailable: Flower[];
   flowersSelected: string[];
   productMetadata: ProductMetadata;
@@ -32,6 +32,7 @@ export type BouquetSettingsForm = {
   paletteOptionValuesToRemove: string[];
   paletteOptionValuesToAdd: string[];
   paletteBackendIdToName: TwoWayFallbackMap;
+  sizeEnumToName: TwoWayFallbackMap;
   allFocalFlowerOptions: string[];
   flowersSelected: string[]
   flowerOptionValuesToRemove: string[];
@@ -50,6 +51,7 @@ export type SerializedSettingForm = {
   paletteOptionValuesToRemove: string[];
   paletteOptionValuesToAdd: string[];
   paletteBackendIdToName: SerializedTwoWayFallbackMap;
+  sizeEnumToName: SerializedTwoWayFallbackMap;
   allFocalFlowerOptions: string[];
   flowersSelected: string[];
   flowerOptionValuesToRemove: string[];
@@ -72,6 +74,8 @@ export type SerializedCustomizeForm = {
   optionToNameUpdates: { [key: string]: string };
   paletteToNameUpdates: { [key: string]: string };
   paletteBackendIdToName: SerializedTwoWayFallbackMap;
+  sizeToNameUpdates: { [key: string]: string };
+  sizeEnumToName: SerializedTwoWayFallbackMap;
 }
 
 export type FocalFlowersSectionProps = {
@@ -123,6 +127,7 @@ export type BouquetCustomizationForm = {
   flowerToPriceUpdates: { [key: string]: number };
   optionToNameUpdates: { [key: string]: string };
   paletteToNameUpdates: { [key: string]: string };
+  sizeToNameUpdates: { [key: string]: string };
 };
 
 export type OptionCustomization = {
@@ -159,4 +164,5 @@ export type ProductMetadata = {
   flowerToPrice: { [key: string]: number };
   optionToName: { [key: string]: string };
   paletteToName: { [key: string]: string }; // backend palette id (as string) to custom palette name
+  sizeToName: { [key: string]: string }; // size enum to custom name
 }

--- a/shopify.app.foxtail-designs.toml
+++ b/shopify.app.foxtail-designs.toml
@@ -3,7 +3,7 @@
 client_id = "276741cc496195767e491f77bc719d46"
 name = "foxtail-designs"
 handle = "foxtail-designs-1"
-application_url = "https://recommends-fate-complications-k.trycloudflare.com"
+application_url = "https://blink-portland-niagara-valued.trycloudflare.com"
 embedded = true
 
 [build]
@@ -17,9 +17,9 @@ scopes = "read_products,write_products"
 
 [auth]
 redirect_urls = [
-  "https://recommends-fate-complications-k.trycloudflare.com/auth/callback",
-  "https://recommends-fate-complications-k.trycloudflare.com/auth/shopify/callback",
-  "https://recommends-fate-complications-k.trycloudflare.com/api/auth/callback"
+  "https://blink-portland-niagara-valued.trycloudflare.com/auth/callback",
+  "https://blink-portland-niagara-valued.trycloudflare.com/auth/shopify/callback",
+  "https://blink-portland-niagara-valued.trycloudflare.com/api/auth/callback"
 ]
 
 [webhooks]


### PR DESCRIPTION
Similar to #25 but for sizes:
- use product metadata field to map the size identifier to custom name
- update the option values using graphql
UX changes:

In Settings page, the custom size value name will be displayed if present
<img width="417" alt="Screenshot 2024-07-30 at 3 29 33 PM" src="https://github.com/user-attachments/assets/7284f8ce-e37e-40c9-9317-68cb111f13a2">

In Customize page, the text box for customization will be populated with the current custom size value name
<img width="940" alt="Screenshot 2024-07-30 at 3 29 25 PM" src="https://github.com/user-attachments/assets/320cb14d-37f7-4c2a-b43e-065bc486d7e4">

