### PR TITLE
Add Foxtail banner, instruction changes

### DIFF
--- a/app/components/focal-flowers/FocalFlowersSection.tsx
+++ b/app/components/focal-flowers/FocalFlowersSection.tsx
@@ -209,7 +209,7 @@ export const FocalFlowersSection = ({
           <Combobox.TextField
             id="flowers"
             autoComplete="off"
-            label="Choose what main flowers you want to offer. The customer will be allowed to choose one (1) main flower for their bouquet."
+            label="Choose up to five (5) main flowers you want to offer. Your customer will be allowed to choose one (1) main flower for their bouquet. You can edit prices on the next page."
             value={value}
             suggestion={suggestion}
             placeholder="Add main flowers"

--- a/app/components/palettes/PaletteSection.tsx
+++ b/app/components/palettes/PaletteSection.tsx
@@ -89,7 +89,7 @@ export const PaletteSection = ({
         Palette Color Options
       </Text>
       <Text as={"p"} variant="bodyMd">
-        Choose what color palettes you want to offer.
+        Choose up to five (5) color palettes you want to offer. You can edit the names on the next page.
       </Text>
         {inlineError(errors?.palettes, "palettes")}
         {!errors?.palettes && inlineError(validationError, "palettes")}

--- a/app/components/sizes/SizeSection.tsx
+++ b/app/components/sizes/SizeSection.tsx
@@ -44,7 +44,7 @@ export const SizeSection = ({
         Size options
       </Text>
       <ChoiceList
-        title="Choose what bouquet sizes you want to offer."
+        title="Choose what bouquet sizes you want to offer. You can edit the names and prices on the next page."
         allowMultiple
         choices={allSizesAvailable.map((option) => {
           return { label: getDisplayName(option), value: option };

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -97,7 +97,7 @@ const ByobProduct = (
     <BlockStack gap="200">
       <InlineGrid columns="1fr auto">
         <Text as="h2" variant="headingMd">
-          Build-Your-Own-Bouquet
+          Build-Your-Own-Bouquet Product Generator
         </Text>
         {(!!productId && isBannerDismissed) &&
           <Button
@@ -110,7 +110,7 @@ const ByobProduct = (
         }
       </InlineGrid>
       <Text as="p" variant="bodyMd">
-        Give customers the option to buy a custom arrangement! Select the
+        Give your customers the option to buy a custom arrangement! Select the
         customizations you want to offer and generate all of the Shopify variants
         with a few clicks.
       </Text>
@@ -164,7 +164,7 @@ const Foxtail = ({ onAction }: ActionProps) => (
         </Button>
       </InlineGrid>
       <Text as="p" variant="bodyMd">
-        At Foxtail, we turn floral design ideas into visual images early on in the design process.
+        At Foxtail, we're turning floral design ideas into visual images early on in the design process.
         We’re building online tools to make it easier for clients and florists to understand what
         an order will look like, from color palettes to shape and style.
       </Text>
@@ -217,29 +217,39 @@ export default function Index() {
   const showBanner = !isBannerDismissed && product.onlineStorePreviewUrl && nav.state === "idle";
 
   return (
-    <Page>
-      <Layout>
-        <Layout.Section>
-          {showBanner && (
-            <SuccessBanner setIsDismissed={setIsBannerDismissed} previewLink={product.onlineStorePreviewUrl!} />
-          )}
-        </Layout.Section>
-        <Layout.Section>
-          <InlineGrid gap="300" columns={2}>
-            <ByobProduct
-              isBannerDismissed={isBannerDismissed}
-              onPreviewAction={() => window.open(product.onlineStorePreviewUrl)?.focus()}
-              onEditAction={onEdit}
-              onDeleteAction={onDelete}
-              productId={product.id}
-              isEditLoading={isEditing}
-              isDeleteLoading={isDeleting}
-            />
-            <Foxtail onAction={() => window.open("https://foxtailcreates.com/")?.focus()} />
-            <ContactUs onAction={() => window.open("mailto:foxtailcreates@gmail.com?Subject=Hello")} />
-          </InlineGrid>
-        </Layout.Section>
-      </Layout>
-    </Page>
+    <>
+      <div
+        className="square-color2"
+        style={{ backgroundColor: "#F05F40", padding: "1rem" }}
+      >
+        <Text variant="heading2xl" as="h2" alignment="center" tone="text-inverse">
+          Foxtail Designs
+        </Text>
+      </div>
+      <Page>
+        <Layout>
+          <Layout.Section>
+            {showBanner && (
+              <SuccessBanner setIsDismissed={setIsBannerDismissed} previewLink={product.onlineStorePreviewUrl!} />
+            )}
+          </Layout.Section>
+          <Layout.Section>
+            <InlineGrid gap="300" columns={2}>
+              <ByobProduct
+                isBannerDismissed={isBannerDismissed}
+                onPreviewAction={() => window.open(product.onlineStorePreviewUrl)?.focus()}
+                onEditAction={onEdit}
+                onDeleteAction={onDelete}
+                productId={product.id}
+                isEditLoading={isEditing}
+                isDeleteLoading={isDeleting}
+              />
+              <Foxtail onAction={() => window.open("https://foxtailcreates.com/")?.focus()} />
+              <ContactUs onAction={() => window.open("mailto:foxtailcreates@gmail.com?Subject=Hello")} />
+            </InlineGrid>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    </>
   );
 }

--- a/app/routes/app.bouquets.customize.tsx
+++ b/app/routes/app.bouquets.customize.tsx
@@ -233,7 +233,7 @@ export default function ByobCustomizationForm() {
                       <Text as="h2" variant="headingMd">
                         Sizes
                       </Text>
-                      <List type="number">
+                      <List type="bullet">
                         <List.Item>
                           {"Customize the naming for your size options -- for example, rename \"Small\" to \"Modest\"."}
                         </List.Item>
@@ -259,7 +259,7 @@ export default function ByobCustomizationForm() {
                       <Text as="h2" variant="headingMd">
                         Palettes
                       </Text>
-                      <List type="number">
+                      <List type="bullet">
                         <List.Item>
                           {"Customize the naming for your palette options - for example, rename \"Pastel\" to \"Soft\"."}
                         </List.Item>
@@ -282,11 +282,15 @@ export default function ByobCustomizationForm() {
                       <Text as="h2" variant="headingMd">
                         Main Flowers
                       </Text>
-                      <List type="number">
+                      <List type="bullet">
                         <List.Item>
-                          Edit the add-on price for each main flower. If the customer chooses a main flower with an add-on price, this will be in addition to the base price for the product.
+                          Edit the add-on price for each main flower. 
                         </List.Item>
                       </List>
+                      <Text as="h2" variant="bodyMd">
+                        If the customer chooses a main flower with an add-on price, this will be in addition to the base price for the product.
+                        For example, if the base price for a "Small" bouquet is $40 and the customer chooses a main flower with an add-on price of $5, the total price will be $45.
+                        </ Text>
                     </>
                   }
                   optionCustomizations={form.optionCustomizations[FLOWER_OPTION_NAME]}

--- a/app/routes/app.bouquets.settings.tsx
+++ b/app/routes/app.bouquets.settings.tsx
@@ -242,8 +242,8 @@ export default function ByobCustomizationForm() {
                   Customizations
                 </Text>
                 <Text as={"h3"} variant="bodyMd">
-                  Choose which product options are available to a
-                  customer. You can edit names and prices in the next page.
+                  Choose which product options are available to your
+                  customer.
                 </Text>
                 <Divider />
                 <SizeSection


### PR DESCRIPTION
Addresses:
- In settings, make it clearer that the focal flowers will get an additional price setting on the next page
- Make pricing easier to understand, e.g. an example? (Isaac's feedback)
- in instructions, say choose up to 5 palettes/flowers

Not yet addressed:
- NaN after pressing backspace (maybe we can debounce this?)
- Home page could make it clearer that it's from a florist's POV (Isaac's feedback)