### PR TITLE
Update url to meet shopify requirements

### DIFF
--- a/shopify.app.custom-bouquet-builder.toml
+++ b/shopify.app.custom-bouquet-builder.toml
@@ -1,0 +1,28 @@
+# Config file for public production app
+# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "d8cfe2c468c475c4942b5f2d3dc47174"
+name = "Custom Bouquet Builder"
+handle = "custom-bouquet-builder"
+application_url = "https://bouquet.foxtailcreates.com"
+embedded = true
+
+[build]
+include_config_on_deploy = true
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+scopes = "write_inventory,write_products,write_publications"
+
+[auth]
+redirect_urls = [
+  "https://bouquet.foxtailcreates.com/auth/callback",
+  "https://bouquet.foxtailcreates.com/auth/shopify/callback",
+  "https://bouquet.foxtailcreates.com/api/auth/callback"
+]
+
+[webhooks]
+api_version = "2024-07"
+
+[pos]
+embedded = false

--- a/shopify.app.foxtail-designs-dev-2.toml
+++ b/shopify.app.foxtail-designs-dev-2.toml
@@ -1,3 +1,4 @@
+# Config file for dev2 testing environment
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "ff76bcd4fb1407f5be050deaaaf74190"

--- a/shopify.app.foxtail-designs-dev.toml
+++ b/shopify.app.foxtail-designs-dev.toml
@@ -1,3 +1,4 @@
+# Config file for dev1 testing environment
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "226b7db4be96cc6154d0eeb8aaa17f28"

--- a/shopify.app.foxtail-designs.toml
+++ b/shopify.app.foxtail-designs.toml
@@ -1,3 +1,4 @@
+# Config file for custom production app
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "276741cc496195767e491f77bc719d46"


### PR DESCRIPTION
Shopify doesn't allow you have to have "shopify" in the url and render doesn't allow you to rename your url :') I've added a custom domain `https://bouquet.foxtailcreates.com/` for the render url. 

Also add some comments to label the config files