### PR TITLE
Update homepage layout for clearer user flows

### DIFF
--- a/app/server/controllers/activateProductInOnlineStore.ts
+++ b/app/server/controllers/activateProductInOnlineStore.ts
@@ -11,7 +11,7 @@ export async function activateProductInOnlineStore(admin: AdminApiContext, produ
 
     if (product.publishedAt == null) {
       const publications = await getPublications(admin);
-      const onlineStore = publications?.nodes.find( (node) => node.catalog.title.endsWith("Online Store"));
+      const onlineStore = publications?.nodes.find( (node) => node.catalog?.title.endsWith("Online Store"));
       if (onlineStore == null) {
         throw "Unable to publish product to Online Store. Could not find Online Store in publications."
         + " Please confirm that Online Store is available.";

--- a/app/server/graphql/queries/product/getProductById.ts
+++ b/app/server/graphql/queries/product/getProductById.ts
@@ -16,6 +16,6 @@ export const GET_PRODUCT_PREVIEW_BY_ID_QUERY = `#graphql
       product(id:$id) {
         id
         onlineStorePreviewUrl
-        onlineStoreUrl
+        publishedAt
       }
     }`;

--- a/app/server/services/getProductPreview.ts
+++ b/app/server/services/getProductPreview.ts
@@ -1,0 +1,19 @@
+import { FetchResponseBody } from "@shopify/admin-api-client";
+import { AdminApiContext } from "@shopify/shopify-app-remix/server";
+import { GetProductPreviewByIdQuery } from "~/types/admin.generated";
+import { sendQuery } from "../graphql/client/sendQuery";
+import { GET_PRODUCT_PREVIEW_BY_ID_QUERY } from "../graphql/queries/product/getProductById";
+
+export async function getProductPreview(admin: AdminApiContext, productId: string) {
+    const productBody: FetchResponseBody<GetProductPreviewByIdQuery> = await sendQuery(
+      admin,
+      GET_PRODUCT_PREVIEW_BY_ID_QUERY,
+      {
+        variables: {
+          id: productId
+        },
+      },
+    )
+    return productBody.data?.product;
+  }
+  


### PR DESCRIPTION
- Update homepage layout
- add `onlineStoreUrl` to determine whether product is published

Not included: 
- publish/unpublish actions when clicking buttons
- removing publish as the last step after saving in the Template Editor form

No product linked:
<img width="903" alt="Screenshot 2024-09-02 at 11 07 50 AM" src="https://github.com/user-attachments/assets/bd77ee98-eccb-43ee-8f36-2cc51e7e15a7">

Product linked:
<img width="613" alt="Screenshot 2024-09-02 at 1 43 16 PM" src="https://github.com/user-attachments/assets/f89c77a1-230e-4209-8aa4-f93c28aaca3e">

