### PR TITLE
Add publish/unpublish hooks

### DIFF
--- a/app/routes/app.bouquets.customize.tsx
+++ b/app/routes/app.bouquets.customize.tsx
@@ -36,10 +36,10 @@ import { Flower, Palette } from "@prisma/client";
 import { FLOWER_OPTION_NAME, PALETTE_OPTION_NAME, SIZE_OPTION_NAME } from "~/constants";
 import { TwoWayFallbackMap } from "~/server/utils/TwoWayFallbackMap";
 import { sanitizeData } from "~/server/utils/sanitizeData";
-import { activateProductInOnlineStore } from "~/server/controllers/activateProductInOnlineStore";
 import { captureException } from "@sentry/remix";
 import { ServerErrorBanner } from "~/components/errors/ServerErrorBanner";
 import { CustomizationsFormSkeleton } from "~/components/skeletons/CustomizationsFormSkeleton";
+import { activateProduct } from "~/server/services/activateProduct";
 
 const SETTINGS_PATH = "/app/bouquets/settings";
 
@@ -61,8 +61,7 @@ export async function action({ request }) {
 
     sanitizeData(data);
     await saveCustomizations(admin, data);
-    await activateProductInOnlineStore(admin, data.product);
-
+    await activateProduct(admin, data.product.id);
     return redirect(`/app`);
   } catch (err) {
     console.error(err);

--- a/app/server/controllers/activateProductInOnlineStore.ts
+++ b/app/server/controllers/activateProductInOnlineStore.ts
@@ -1,15 +1,15 @@
-import { ProductFieldsFragment } from "~/types/admin.generated";
 import { activateProduct } from "../services/activateProduct";
 import { getPublications } from "../services/getPublications";
 import { publishProduct } from "../services/publishProduct";
 import { AdminApiContext } from "@shopify/shopify-app-remix/server";
 
-export async function activateProductInOnlineStore(admin: AdminApiContext, product: ProductFieldsFragment) {
-    if (product.status !== "ACTIVE") {
-      await activateProduct(admin, product.id);
+export async function publishProductInOnlineStore(admin: AdminApiContext,
+  productId: string, publishedAt: string, status: string) {
+    if (status !== "ACTIVE") {
+      await activateProduct(admin, productId);
     }
 
-    if (product.publishedAt == null) {
+    if (publishedAt == null || publishedAt === "null") {
       const publications = await getPublications(admin);
       const onlineStore = publications?.nodes.find( (node) => node.catalog?.title.endsWith("Online Store"));
       if (onlineStore == null) {
@@ -17,6 +17,6 @@ export async function activateProductInOnlineStore(admin: AdminApiContext, produ
         + " Please confirm that Online Store is available.";
       }
 
-      await publishProduct(admin, product.id, onlineStore.id);
+      await publishProduct(admin, productId, onlineStore.id);
     }
   }

--- a/app/server/controllers/unpublishProductInOnlineStore.ts
+++ b/app/server/controllers/unpublishProductInOnlineStore.ts
@@ -1,0 +1,17 @@
+import { getPublications } from "../services/getPublications";
+import { AdminApiContext } from "@shopify/shopify-app-remix/server";
+import { unpublishProduct } from "../services/unpublishProduct";
+
+export async function unpublishProductInOnlineStore(admin: AdminApiContext,
+  productId: string, publishedAt: string) {
+    if (publishedAt == null || publishedAt === "null") {
+      const publications = await getPublications(admin);
+      const onlineStore = publications?.nodes.find( (node) => node.catalog?.title.endsWith("Online Store"));
+      if (onlineStore == null) {
+        throw "Unable to unpublish product in Online Store. Could not find Online Store in publications."
+        + " Please confirm that Online Store is available sales channel.";
+      }
+
+      await unpublishProduct(admin, productId, onlineStore.id);
+    }
+  }

--- a/app/server/graphql/index.js
+++ b/app/server/graphql/index.js
@@ -9,6 +9,7 @@ export { CREATE_PRODUCT_WITH_OPTIONS_QUERY } from "./queries/product/createProdu
 export { UPDATE_PRODUCT_QUERY } from "./queries/product/updateProduct";
 export { SET_PRODUCT_METAFIELD_QUERY } from "./queries/product/setProductMetafield";
 export { ACTIVATE_PRODUCT_QUERY } from "./queries/product/activateProduct"
+
 export { GET_PRODUCT_BY_ID_QUERY } from "./queries/product/getProductById";
 export { CREATE_PRODUCT_OPTIONS_QUERY } from "./queries/productOption/createProductOptions";
 export { UPDATE_PRODUCT_OPTION_AND_VARIANTS_QUERY } from "./queries/productOption/updateProductOptionAndVariants";
@@ -23,3 +24,4 @@ export { DELETE_PRODUCT_MEDIA_QUERY } from "./queries/product/deleteProductMedia
 
 export { GET_PUBLICATIONS_QUERY } from "./queries/publication/getPublications";
 export { PUBLISH_PRODUCT_QUERY } from "./queries/publication/publishProduct";
+export { UNPUBLISH_PRODUCT_QUERY } from "./queries/publication/unpublishProduct";

--- a/app/server/graphql/queries/product/getProductById.ts
+++ b/app/server/graphql/queries/product/getProductById.ts
@@ -17,5 +17,6 @@ export const GET_PRODUCT_PREVIEW_BY_ID_QUERY = `#graphql
         id
         onlineStorePreviewUrl
         publishedAt
+        status
       }
     }`;

--- a/app/server/graphql/queries/publication/unpublishProduct.ts
+++ b/app/server/graphql/queries/publication/unpublishProduct.ts
@@ -1,0 +1,11 @@
+export const UNPUBLISH_PRODUCT_QUERY = `#graphql
+  mutation unpublishProduct($id:ID!, $publicationId:ID!) {
+    publishableUnpublish(id:$id,
+      input: {publicationId: $publicationId}
+    ) {
+      userErrors {
+        message
+        field
+      }
+    }
+  }`;

--- a/app/server/services/unpublishProduct.ts
+++ b/app/server/services/unpublishProduct.ts
@@ -1,0 +1,28 @@
+import { AdminApiContext } from "@shopify/shopify-app-remix/server";
+import { UNPUBLISH_PRODUCT_QUERY } from "../graphql";
+import { sendQuery } from "../graphql/client/sendQuery";
+import { UnpublishProductMutation } from "~/types/admin.generated";
+import { FetchResponseBody } from "@shopify/admin-api-client";
+
+export async function unpublishProduct(
+  admin: AdminApiContext,
+  id: string,
+  publicationId: string
+) {
+  const unpublishProductResponseBody: FetchResponseBody<UnpublishProductMutation> = await sendQuery(
+    admin,
+    UNPUBLISH_PRODUCT_QUERY,
+    {
+      variables: {
+        id: id,
+        publicationId: publicationId
+      },
+    },
+  );
+  const hasErrors: boolean = unpublishProductResponseBody.data?.publishableUnpublish?.userErrors.length != 0;
+  if (hasErrors) {
+    throw new Error("Error unpublishing product.\n User errors: { "
+      + JSON.stringify(unpublishProductResponseBody.data?.publishableUnpublish?.userErrors)
+      + "}");
+  }
+}


### PR DESCRIPTION
- When filling out form, activate product but don't publish it. Shopify's default behavior is for new products to be active
- Add backend for publish/unpublish buttons on the landing page