### PR TITLE
Use app-reserved metafields

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,7 +1,7 @@
 import { ProductMetadata } from "./types";
 import { Size } from "./size";
 
-export const FOXTAIL_NAMESPACE = "foxtail";
+export const FOXTAIL_NAMESPACE = "$app:foxtail";
 export const STORE_METADATA_CUSTOM_PRODUCT_KEY = "customProductId";
 export const PRODUCT_METADATA_CUSTOM_OPTIONS = "custom";
 export const GRAPHQL_API_VERSION = "2024-07";

--- a/app/routes/webhooks.tsx
+++ b/app/routes/webhooks.tsx
@@ -26,8 +26,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       if (session) {
         await db.session.deleteMany({ where: { shop } });
       }
-      // todo: clean up shop metadata field
-
+      // metafields are under app-reserved namespace
       break;
     case "CUSTOMERS_DATA_REQUEST":
       // no customer data saved


### PR DESCRIPTION
By using the reserved prefix, the metafield is private to our app: https://shopify.dev/docs/apps/build/custom-data/reserved-prefixes. **This will break current products until you delete and recreate them**

We can't actually delete the metafields after uninstalling because authentication fails: https://community.shopify.com/c/metafields-and-custom-data/delete-metafields-on-app-uninstalled/td-p/1188729