### PR TITLE
link to managed pricing page

### DIFF
--- a/app/routes/bouquets.plans.tsx
+++ b/app/routes/bouquets.plans.tsx
@@ -1,0 +1,24 @@
+import { LoaderFunctionArgs, json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { authenticate } from "../shopify.server";
+import { useEffect } from "react";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  await authenticate.admin(request);
+
+  return json({
+    appHandle: process.env.APP_HANDLE || ""
+  });
+};
+
+export default function SubscriptionPage() {
+  const { appHandle } = useLoaderData<typeof loader>();
+  useEffect(() => {
+    if (!appHandle) return;
+    open(`https://admin.shopify.com/charges/${appHandle}/pricing_plans`, "_top");
+  }, [appHandle]);
+
+  return (
+    <div>Redirecting...</div>
+  );
+}

--- a/app/routes/bouquets.tsx
+++ b/app/routes/bouquets.tsx
@@ -9,7 +9,6 @@ import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
 import { authenticate } from "../shopify.server";
 import { captureRemixErrorBoundaryError } from "@sentry/remix";
 import ErrorPage from "~/components/errors/ErrorPage";
-import { useEffect } from "react";
 
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
@@ -18,25 +17,17 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   return json({
     apiKey: process.env.SHOPIFY_API_KEY || "",
-    appHandle: process.env.APP_HANDLE || ""
-   });
+  });
 };
 
 export default function App() {
-  const { apiKey, appHandle} = useLoaderData<typeof loader>();
-
-  const priceUrl: string = `shopify://admin/charges/${appHandle}/pricing_plans`;
-  console.log(priceUrl);  
+  const { apiKey } = useLoaderData<typeof loader>();
 
   return (
     <AppProvider isEmbeddedApp apiKey={apiKey}>
       <NavMenu>
-        <Link to="/bouquets" rel="home">
-          Home
-        </Link>
-        <Link to={priceUrl}>
-          Pricing
-        </Link>
+        <Link to="/bouquets" rel="home"> Home </Link>
+        <Link to="/bouquets/plans"> Plans </Link>
       </NavMenu>
       <Outlet />
     </AppProvider>


### PR DESCRIPTION
Add pricing link to navigation menu:
- Add wrapper pricing page that redirects to the Shopify-provided managed pricing page
- Add link to app-bridge NavMenu

Unfortunately we can't link directly to the managed pricing page in NavMenu due to a app-bridge bug https://shopifypartners.slack.com/archives/C075A2D1PA4/p1718168440993189