### PR TITLE
handle failed variant update

### DIFF
--- a/app/server/services/updateProductOptionsAndVariants.ts
+++ b/app/server/services/updateProductOptionsAndVariants.ts
@@ -31,9 +31,15 @@ export async function updateProductOptionsAndVariants(
 
   const hasErrors: boolean = updateProductOptionNameBody.data?.productOptionUpdate?.userErrors.length != 0;
   if (hasErrors) {
-    throw new Error("Error updating variants.\n User errors: { "
-      + JSON.stringify(updateProductOptionNameBody.data?.productOptionUpdate?.userErrors)
-      + "}");
+    if (updateProductOptionNameBody.data?.productOptionUpdate?.userErrors.every(e => e.message === "Option value already exists.")) {
+      console.log("Product options not updated. User errors: {"
+        + JSON.stringify(updateProductOptionNameBody.data?.productOptionUpdate?.userErrors
+          + "}"));
+    } else {
+      throw new Error("Error updating variants.\n User errors: { "
+        + JSON.stringify(updateProductOptionNameBody.data?.productOptionUpdate?.userErrors)
+        + "}");
+    }
   }
   return updateProductOptionNameBody.data?.productOptionUpdate?.product;
 }


### PR DESCRIPTION
If product variants failed to update because all the options already exist, then we can safely continue.